### PR TITLE
Add support for the Reply-To header if passed in.

### DIFF
--- a/sparkpost-wp-mail.php
+++ b/sparkpost-wp-mail.php
@@ -220,7 +220,13 @@ function _sparkpost_wp_mail_headers( $headers, $message_args ) {
 			case 'subject':
 			case 'from':
 			case 'to':
+				unset( $headers[ $index ] );
+				break;
+
 			case 'reply-to':
+				if ( ! empty( $headers[ $index ] ) ) {
+					$message_args['content']['reply_to'] = $content;
+				}
 				unset( $headers[ $index ] );
 				break;
 


### PR DESCRIPTION
Copy any Reply-To header from the original headers array to the correct place in Sparkpost's structure.
